### PR TITLE
fix: typescript 4.4+ compatibility

### DIFF
--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -19,7 +19,7 @@ export const isFlagSupported = (flag: string, helpOutput: string): boolean => {
 export const compile = async (options: TypeScriptOptions): Promise<string[]> => {
   let flagSupported: (flag: string) => boolean = () => true
   try {
-    const { all: helpOutput } = await execa('tsc', ['--help'], { all: true, preferLocal: true })
+    const { all: helpOutput } = await execa('tsc', ['--help', '--all'], { all: true, preferLocal: true })
     if (helpOutput !== undefined) {
       flagSupported = (flag: string): boolean => isFlagSupported(flag, helpOutput)
     }


### PR DESCRIPTION
All granular "strict" flags are hidden from `tsc --help` output. Need to call it with `--all` (backwards compatible), otherwise `tsc` was called only with `--noEmit` flag and ts-strictify reported everything is great and no strict errors.