### PR TITLE
fix: be looser with typescript as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "yargs": "^15.3.0"
   },
   "peerDependencies": {
-    "typescript": "3.x"
+    "typescript": ">=3"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",


### PR DESCRIPTION
allow `>=3` instead of just `3.x`