### PR TITLE
fix: avoid swallowing internal errors while executing tsc

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,30 +50,35 @@ const run = async (): Promise<void> => {
     'targetBranch',
   ])
 
-  const result = await strictify({
-    gitOptions,
-    typeScriptOptions,
-    onFoundChangedFiles: (changedFiles) => {
-      console.log(
-        `🎯  Found ${chalk.bold(String(changedFiles.length))} changed ${
-          changedFiles.length === 1 ? 'file' : 'files'
-        }`,
-      )
-    },
-    onExamineFile: (file) => {
-      console.log(`🔍  Checking ${chalk.bold(file)} ...`)
-    },
-    onCheckFile: (file, hasError) =>
-      hasError
-        ? console.log(`❌  ${chalk.bold(file)} failed`)
-        : console.log(`✅  ${chalk.bold(file)} passed`),
-  })
+  try {
+    const result = await strictify({
+      gitOptions,
+      typeScriptOptions,
+      onFoundChangedFiles: (changedFiles) => {
+        console.log(
+          `🎯  Found ${chalk.bold(String(changedFiles.length))} changed ${
+            changedFiles.length === 1 ? 'file' : 'files'
+          }`,
+        )
+      },
+      onExamineFile: (file) => {
+        console.log(`🔍  Checking ${chalk.bold(file)} ...`)
+      },
+      onCheckFile: (file, hasError) =>
+        hasError
+          ? console.log(`❌  ${chalk.bold(file)} failed`)
+          : console.log(`✅  ${chalk.bold(file)} passed`),
+    })
 
-  if (result.errors) {
-    console.log(`💥  ${result.errors} errors found`)
+    if (result.errors) {
+      console.log(`💥  ${result.errors} errors found`)
+      process.exit(1)
+    } else {
+      console.log(`🎉  ${chalk.green('All files passed')}`)
+    }
+  } catch (error) {
+    console.log('message' in error ? error.message : error)
     process.exit(1)
-  } else {
-    console.log(`🎉  ${chalk.green('All files passed')}`)
   }
 }
 run()

--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -20,7 +20,10 @@ export const isFlagSupported = (flag: string, helpOutput: string): boolean => {
 export const compile = async (options: TypeScriptOptions): Promise<string[]> => {
   let flagSupported: (flag: string) => boolean = () => true
   try {
-    const { all: helpOutput } = await execa('tsc', ['--help', '--all'], { all: true, preferLocal: true })
+    const { all: helpOutput } = await execa('tsc', ['--help', '--all'], {
+      all: true,
+      preferLocal: true,
+    })
     if (helpOutput !== undefined) {
       flagSupported = (flag: string): boolean => isFlagSupported(flag, helpOutput)
     }
@@ -38,6 +41,10 @@ export const compile = async (options: TypeScriptOptions): Promise<string[]> => 
     await execa('tsc', args, { all: true, preferLocal: true })
   } catch (error) {
     const { all } = error
+    if (!all) {
+      // forward error when there is no data about processed files in the output - internal error
+      throw error
+    }
     tscOutput = (all as string).split('\n')
   }
   return tscOutput


### PR DESCRIPTION
We had an issue on CI with the `tsc` command executed internally by `ts-strictify` that it was getting killed with SIGKILL, error returned by `execa` was "Command was killed with SIGKILL (Forced termination)" but `ts-strictify` was swallowing the error, returning "success" message instead. (as in: no strict errors detected)

This PR contains a fix to avoid swallowing internal errors while executing tsc.