### PR TITLE
fix: now reporting errors on windows

### DIFF
--- a/src/ts-strictify.ts
+++ b/src/ts-strictify.ts
@@ -1,6 +1,6 @@
 import { GitOptions, findChangedFiles } from './lib/git'
 import { TypeScriptOptions, compile } from './lib/typescript'
-import { relative } from 'path'
+import { relative, sep, posix } from 'path'
 
 export interface Args {
   typeScriptOptions: TypeScriptOptions
@@ -31,7 +31,7 @@ export const strictify = async (args: Args): Promise<StrictifyResult> => {
   const errorCount = changedFiles.reduce<number>((totalErrorCount, fileName) => {
     let errorCount = 0
     tscOut.map((line) => {
-      if (line.includes(relative(process.cwd(), fileName))) {
+      if (line.includes(relative(process.cwd(), fileName).split(sep).join(posix.sep))) {
         errorCount === 0 ? onCheckFile(fileName, true) : null
         totalErrorCount++
         errorCount++


### PR DESCRIPTION
`tsc` output uses posix separators while `path` uses windows separators. This fixes the issue by using posix everywhere