### PR TITLE
fix: noUncheckedIndexedAccess should be false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Options:
   --strictNullChecks                              [boolean] [default: true]
   --strictFunctionTypes                           [boolean] [default: true]
   --strictPropertyInitialization                  [boolean] [default: true]
-  --noUncheckedIndexedAccess                      [boolean] [default: true]
+  --noUncheckedIndexedAccess                     [boolean] [default: false]
   --noEmit                                        [boolean] [default: true]
   --targetBranch                               [string] [default: "master"]
   --commitedFiles                                 [boolean] [default: true]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ const run = async (): Promise<void> => {
       strictNullChecks: { type: 'boolean', default: true },
       strictFunctionTypes: { type: 'boolean', default: true },
       strictPropertyInitialization: { type: 'boolean', default: true },
-      noUncheckedIndexedAccess: { type: 'boolean', default: true },
+      noUncheckedIndexedAccess: { type: 'boolean', default: false },
       noEmit: { type: 'boolean', default: true },
       targetBranch: { type: 'string', default: 'master' },
       commitedFiles: { type: 'boolean', default: true },


### PR DESCRIPTION
`noUncheckedIndexedAccess` should be turned off by default

because even `strict: true` in `tsconfig.json` does not enable it - see https://github.com/microsoft/TypeScript/issues/49169